### PR TITLE
feat: refactor booking

### DIFF
--- a/src/ProviderApi.ts
+++ b/src/ProviderApi.ts
@@ -17,11 +17,11 @@ import {
     ApiSignedProviderAppointment,
     Appointment,
     AppointmentStatus,
-    Booking,
     BookingData,
     ECDHData,
     Provider,
     ProviderBackup,
+    ProviderBooking,
     ProviderInput,
     ProviderKeyPairs,
     PublicAppointment,
@@ -574,12 +574,17 @@ export class ProviderApi extends AbstractApi<
                         providerKeyPairs
                     );
 
-                    const bookings: Booking[] = apiBookings.map(
+                    const enrichedAppointment = enrichAppointment(
+                        apiAppointment,
+                        provider
+                    );
+
+                    const bookings: ProviderBooking[] = apiBookings.map(
                         (apiBooking) => ({
                             slotId: apiBooking.id,
-                            appointmentId: apiAppointment.id,
-                            providerId: provider.id,
-                            code: apiBooking.userToken.code,
+                            appointment: enrichedAppointment,
+                            token: apiBooking.userToken,
+                            signedToken: apiBooking.signedToken,
                         })
                     );
 
@@ -616,7 +621,7 @@ export class ProviderApi extends AbstractApi<
                     }
 
                     const appointment: Appointment = {
-                        ...enrichAppointment(apiAppointment, provider),
+                        ...enrichedAppointment,
                         updatedAt: dayjs(signedAppointment.updatedAt)
                             .utc()
                             .toDate(),

--- a/src/UserApi.ts
+++ b/src/UserApi.ts
@@ -70,9 +70,10 @@ export class UserApi extends AbstractApi<
 
             const booking: Booking = {
                 slotId: apiBooking.id,
-                appointmentId: appointment.id,
-                providerId: appointment.provider.id,
-                code: userQueueToken.userToken.code,
+                token: userQueueToken.userToken,
+                signedToken: userQueueToken.signedToken,
+                keyPairs: userQueueToken.keyPairs,
+                appointment,
             };
 
             return booking;
@@ -91,18 +92,15 @@ export class UserApi extends AbstractApi<
      *
      * @returns Promise<boolean>
      */
-    public async cancelBooking(
-        booking: Booking,
-        userQueueToken: UserQueueToken
-    ) {
+    public async cancelBooking(booking: Booking) {
         const result = await this.transport.call(
             "cancelAppointment",
             {
-                id: booking.appointmentId,
-                providerID: booking.providerId,
-                signedTokenData: userQueueToken.signedToken,
+                id: booking.appointment.id,
+                providerID: booking.appointment.provider.id,
+                signedTokenData: booking.signedToken,
             },
-            userQueueToken.keyPairs.signing
+            booking.keyPairs.signing
         );
 
         if ("ok" !== result) {
@@ -123,8 +121,8 @@ export class UserApi extends AbstractApi<
         const anonApi = new AnonymousApi(this.config);
 
         const appointment = await anonApi.getAppointment(
-            booking.appointmentId,
-            booking.providerId,
+            booking.appointment.id,
+            booking.appointment.provider.id,
             true
         );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,6 @@ export * from "./errors";
 export * from "./interfaces";
 export * from "./MediatorApi";
 export * from "./ProviderApi";
-export * from "./storage";
 export * from "./StorageApi";
 export * from "./transports";
 export * from "./UserApi";

--- a/src/interfaces/Appointment.ts
+++ b/src/interfaces/Appointment.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2021-2021 The Kiebitz Authors
 // README.md contains license information.
 
-import type { Booking } from "./Booking";
+import type { ProviderBooking } from "./Booking";
 import type { PublicProvider } from "./Provider";
 
 export interface Slot {
@@ -37,7 +37,7 @@ export enum AppointmentStatus {
 }
 
 export interface Appointment extends PublicAppointment {
-    bookings: Booking[];
+    bookings: ProviderBooking[];
     status: AppointmentStatus;
     updatedAt: Date;
 }

--- a/src/interfaces/Booking.ts
+++ b/src/interfaces/Booking.ts
@@ -2,6 +2,13 @@
 // Copyright (C) 2021-2021 The Kiebitz Authors
 // README.md contains license information.
 
+import {
+    AggregatedPublicAppointment,
+    SignedData,
+    UserKeyPairs,
+    UserToken,
+} from ".";
+
 export enum BookingStatus {
     VALID = "VALID",
     PROVIDER_CANCELED = "PROVIDER_CANCELED",
@@ -9,9 +16,13 @@ export enum BookingStatus {
     UNKNOWN = "UNKNOWN",
 }
 
-export interface Booking {
+export interface ProviderBooking {
     slotId: string;
-    appointmentId: string;
-    providerId: string;
-    code: string;
+    appointment: AggregatedPublicAppointment;
+    token: UserToken;
+    signedToken: SignedData;
+}
+
+export interface Booking extends ProviderBooking {
+    keyPairs: UserKeyPairs;
 }

--- a/src/tests/UserApi.test.ts
+++ b/src/tests/UserApi.test.ts
@@ -191,9 +191,9 @@ describe("UserApi", () => {
 
             expect(booking).not.toBeNull();
             expect(booking.slotId).toBeDefined();
-            expect(booking.code).toEqual(userSecret.slice(0, 4));
-            expect(booking.appointmentId).toEqual(appointment.id);
-            expect(booking.providerId).toEqual(provider.id);
+            expect(booking.token.code).toEqual(userSecret.slice(0, 4));
+            expect(booking.appointment.id).toEqual(appointment.id);
+            expect(booking.appointment.provider.id).toEqual(provider.id);
 
             const status = await context.userApi.checkBookingStatus(booking);
 
@@ -218,9 +218,9 @@ describe("UserApi", () => {
             );
 
             expect(booking.slotId).toBeDefined();
-            expect(booking.code).toEqual(userSecret.slice(0, 4));
-            expect(booking.appointmentId).toEqual(appointment.id);
-            expect(booking.providerId).toEqual(provider.id);
+            expect(booking.token.code).toEqual(userSecret.slice(0, 4));
+            expect(booking.appointment.id).toEqual(appointment.id);
+            expect(booking.appointment.provider.id).toEqual(provider.id);
 
             const doubleBooking = context.userApi.bookAppointment(
                 appointment,
@@ -252,9 +252,9 @@ describe("UserApi", () => {
             );
 
             expect(booking.slotId).toBeDefined();
-            expect(booking.code).toEqual(userSecret.slice(0, 4));
-            expect(booking.appointmentId).toEqual(appointment.id);
-            expect(booking.providerId).toEqual(provider.id);
+            expect(booking.token.code).toEqual(userSecret.slice(0, 4));
+            expect(booking.appointment.id).toEqual(appointment.id);
+            expect(booking.appointment.provider.id).toEqual(provider.id);
 
             const appointments =
                 await context.providerApi.getProviderAppointments(
@@ -263,7 +263,7 @@ describe("UserApi", () => {
                     providerKeyPairs
                 );
 
-            expect(appointments[0].bookings[0].code).toEqual(
+            expect(appointments[0].bookings[0].token.code).toEqual(
                 userSecret.slice(0, 4)
             );
         });
@@ -286,14 +286,11 @@ describe("UserApi", () => {
             );
 
             expect(booking.slotId).toBeDefined();
-            expect(booking.code).toEqual(userSecret.slice(0, 4));
-            expect(booking.appointmentId).toEqual(appointment.id);
-            expect(booking.providerId).toEqual(provider.id);
+            expect(booking.token.code).toEqual(userSecret.slice(0, 4));
+            expect(booking.appointment.id).toEqual(appointment.id);
+            expect(booking.appointment.provider.id).toEqual(provider.id);
 
-            const cancelResult = await context.userApi.cancelBooking(
-                booking,
-                userQueueToken
-            );
+            const cancelResult = await context.userApi.cancelBooking(booking);
 
             expect(cancelResult).toBeTruthy();
 
@@ -324,9 +321,9 @@ describe("UserApi", () => {
             );
 
             expect(booking.slotId).toBeDefined();
-            expect(booking.code).toEqual(userSecret.slice(0, 4));
-            expect(booking.appointmentId).toEqual(appointment.id);
-            expect(booking.providerId).toEqual(provider.id);
+            expect(booking.token.code).toEqual(userSecret.slice(0, 4));
+            expect(booking.appointment.id).toEqual(appointment.id);
+            expect(booking.appointment.provider.id).toEqual(provider.id);
 
             const bookedAppointment = await context.anonymousApi.getAppointment(
                 appointment.id,
@@ -335,10 +332,7 @@ describe("UserApi", () => {
 
             expect(bookedAppointment.slotData[0].open).toEqual(false);
 
-            const cancelResult = await context.userApi.cancelBooking(
-                booking,
-                userQueueToken
-            );
+            const cancelResult = await context.userApi.cancelBooking(booking);
 
             expect(cancelResult).toBeTruthy();
 
@@ -378,9 +372,9 @@ describe("UserApi", () => {
             );
 
             expect(booking.slotId).toBeDefined();
-            expect(booking.code).toEqual(userSecret.slice(0, 4));
-            expect(booking.appointmentId).toEqual(appointment.id);
-            expect(booking.providerId).toEqual(provider.id);
+            expect(booking.token.code).toEqual(userSecret.slice(0, 4));
+            expect(booking.appointment.id).toEqual(appointment.id);
+            expect(booking.appointment.provider.id).toEqual(provider.id);
 
             const cancelResult = await context.providerApi.cancelAppointment(
                 appointment,


### PR DESCRIPTION
depend booking handling only Booking for the user.
A refetch of the booking is only needed to check the status.
Split out ProviderBooking-interface.