### PR TITLE
Feat: replace base32crockford and base64url

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "prepare": "husky install"
     },
     "dependencies": {
-        "@ctrl/ts-base32": "^1.2.6",
+        "@scure/base": "^1.0.0",
         "buffer": "^6.0.3",
         "dayjs": "^1.10.7",
         "destr": "^1.1.0"

--- a/src/utils/base64url.ts
+++ b/src/utils/base64url.ts
@@ -1,21 +1,11 @@
+import { base64url } from "@scure/base";
 import { Buffer } from "buffer";
 
 // https://base64.guru/standards/base64url
-export const encodeBase64url = (string: string | Buffer) => {
-    return Buffer.from(string)
-        .toString("base64")
-        .replace(/\+/g, "-")
-        .replace(/\//g, "_")
-        .replace(/=/g, "");
+export const encodeBase64url = (string: string | Buffer | Uint8Array) => {
+    return base64url.encode(Buffer.from(string));
 };
 
-export const decodeBase64url = (base64url: string) => {
-    return Buffer.from(
-        base64url +
-            "==="
-                .slice((base64url.length + 3) % 4)
-                .replace(/-/g, "+")
-                .replace(/_/g, "/"),
-        "base64"
-    ).toString();
+export const decodeBase64url = (encodedString: string) => {
+    return Buffer.from(base64url.decode(encodedString)).toString();
 };

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -2,15 +2,15 @@
 // Copyright (C) 2021-2021 The Kiebitz Authors
 // README.md contains license information.
 
-import { base32Decode, base32Encode } from "@ctrl/ts-base32";
+import { base32crockford } from "@scure/base";
 import { Buffer } from "buffer";
 
 export const encodeBase32 = (string: string | Buffer) => {
-    return base32Encode(Buffer.from(string), "Crockford");
+    return base32crockford.encode(Buffer.from(string));
 };
 
 export const decodeBase32 = (base32: string) => {
-    return Buffer.from(base32Decode(base32, "Crockford")).toString();
+    return Buffer.from(base32crockford.decode(base32)).toString();
 };
 
 export const bufferToBase64 = (buffer: ArrayBufferLike) => {


### PR DESCRIPTION
Replace custom base64url-encoding and base32-crockford-implementtion
with @scure/base, a package, audited by cure53, with strong focus on security

Details in the repo: https://github.com/paulmillr/scure-base

Tests for both changes exists and are green with no change in output .